### PR TITLE
Random movies with distinct release years

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The `metadata-service` API provides two main modes of operation:
 
 `/?imdbId=<id>`
 
-| Parameter       | Type      |  Default  | Description                                                                                                                   |
-|:----------------|:----------|:---------:|:------------------------------------------------------------------------------------------------------------------------------|
-| `imdbId`        | `ImdbID`  | undefined | Optional. IMDb ID, uniquely identifies a movie. The service will return random movie(s) if the parameter is not given.        |
+| Parameter | Type     |  Default  | Description                                                                                                            |
+| :-------- | :------- | :-------: | :--------------------------------------------------------------------------------------------------------------------- |
+| `imdbId`  | `ImdbID` | undefined | Optional. IMDb ID, uniquely identifies a movie. The service will return random movie(s) if the parameter is not given. |
 
 **Example:**
 
@@ -108,11 +108,13 @@ The `metadata-service` API provides two main modes of operation:
 
 `/?numMovies=<MovieCount>&differentFrom=<OtherImdbID>&notReleasedIn=<ReleaseYear>`
 
-| Parameter       | Type      |  Default  | Description                                                                            |
-|:----------------|:----------|:---------:|:---------------------------------------------------------------------------------------|
-| `numMovies`     | `Integer` |     1     | Optional. Defines how many results should be fetched when fetching random movies.                             |
-| `differentFrom` | `ImdbID`  | undefined | Optional. Defines a base `ImdbID` that will not be included in any random results.     |
-| `notReleasedIn` | `Integer` | undefined | Optional. Defines a release year that movies in the random results should not be from. |
+| Parameter       | Type      |  Default  | Description                                                                               |
+| :-------------- | :-------- | :-------: | :---------------------------------------------------------------------------------------- |
+| `numMovies`     | `Integer` |     1     | Optional. Defines how many results should be fetched when fetching random movies.         |
+| `differentFrom` | `ImdbID`  | undefined | Optional. Defines a base `ImdbID` that will not be included in any random results.        |
+| `notReleasedIn` | `Integer` | undefined | Optional. Defines a release year that movies in the random results should not be from. \* |
+
+_* If `notReleasedIn` is specified, the random results will have distinct release years (i.e., the release year will be different from the specified release year and there will not be two random results having the same release year.)._
 
 ## Test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,6 +1342,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@kwizapp/kwiz-utils": "0.0.2",
+    "core-js": "3.6.4",
     "dotenv": "8.2.0",
     "micro": "9.3.4",
     "pg": "7.18.2",

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -3,6 +3,8 @@ const request = require('supertest')
 
 const server = require('../src/index')
 
+const Set = require('core-js/features/set')
+
 // based on: https://stackoverflow.com/questions/57001262/jest-expect-only-unique-elements-in-an-array
 expect.extend({
   toBeDistinct(received) {


### PR DESCRIPTION
### Description

Return random movies with distinct release years if `notReleasedIn` is specified.

Before this change, the release years were different from the one specified in `notReleasedIn`.
With this change, the release years are also distinct (i.e, there are no two movies having the same release year).

### Related Issues

#24 

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
